### PR TITLE
Add dest argument to install script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 pip3 install --upgrade -r requirements.txt
-activate-global-python-argcomplete
+if [ -z "$1" ]; then
+    activate-global-python-argcomplete
+else
+    activate-global-python-argcomplete --dest=$1
+fi
 cp dockersh /usr/local/bin
 chmod +x /usr/local/bin/dockersh
 cp -n dockersh.ini /etc


### PR DESCRIPTION
Fixes `activate-global-python-argcomplete` on arch linux, where a argument for the `--dest` can be provided.