### PR TITLE
Fix `KeyError: 'ADMIN'` with default configuration.

### DIFF
--- a/dockersh
+++ b/dockersh
@@ -117,7 +117,7 @@ def parse_args():
 cfg = ConfigParser({"USER": user, "HOSTNAME": hostname}, interpolation=ExtendedInterpolation())
 cfg.read(config_file, encoding="utf-8")
 
-if os.getenv("USER") and user != os.getenv('USER') and user in cfg["ADMIN"]["names"].splitlines():
+if os.getenv("USER") and user != os.getenv('USER') and user in cfg.get('ADMIN', 'names', fallback="").splitlines():
     user = os.getenv('USER')
 
     # reread config


### PR DESCRIPTION
With the default configuration, no `ADMIN` field is set.
Therefore a `KeyError` is thrown when trying to access the field.

This PR adds a check, before the `ADMIN` configuration is accessed.